### PR TITLE
Fix type error TS2666: Exports and export assignments are not permitt…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,4 @@ declare module 'mdx-mermaid' {
     export type Mermaid = typeof mMermaid
   }
   type mdxmermaid = typeof plugin
-
-  export = mdxmermaid
 }


### PR DESCRIPTION
…ed in module augmentations.

Fixes typescript issue described below (see https://github.com/Microsoft/TypeScript-Handbook/blob/fa9e2be1024014fe923d44b1b69d315e8347e444/pages/Declaration%20Merging.md#module-augmentation) for more details

```
> tsc
node_modules/mdx-mermaid/index.d.ts:20:3 - error TS2666: Exports and export assignments are not permitted in module augmentations.

20   export = mdxmermaid
     ~~~~~~

Found 1 error.
```