### PR TITLE
fix: data URI scheme for svg output

### DIFF
--- a/src/mdxast-mermaid.ts
+++ b/src/mdxast-mermaid.ts
@@ -90,7 +90,7 @@ const outputSVG: OutputFunc = async (node: CodeMermaid, index: number | null, pa
       jsxElement.openingElement.attributes.push({
         type: 'JSXAttribute',
         name: { type: 'JSXIdentifier', name: 'href' },
-        value: { type: 'Literal', value: `data:text/css;base64.${encoded}` }
+        value: { type: 'Literal', value: `data:text/css;base64,${encoded}` }
       },
         {
           type: 'JSXAttribute',


### PR DESCRIPTION
The PR fixes a typo causing invalid CSS to be loaded.

According to the RFC 2397, comma must be used instead of dot.