### PR TITLE
Prevent SVG transform from clobbering previous nodes

### DIFF
--- a/lib/src/mdxast-mermaid.spec.ts
+++ b/lib/src/mdxast-mermaid.spec.ts
@@ -79,4 +79,29 @@ function MDXContent(props = {}) {
 export default MDXContent;
 `)
   })
+
+  test('multiple mermaid instances in svg don\'t clobber previous node', async () => {
+    const result = await compileMdx(
+      `## Framework AARRR
+
+    Some content
+
+    \`\`\`mermaid
+    graph TD;
+      A-->B;
+    \`\`\`
+
+    And some more:
+
+
+    \`\`\`mermaid
+    graph TD;
+      A-->B;
+    \`\`\``,
+      { output: 'svg' }
+    );
+    expect(result.value).toContain('And some more');
+  })
 })
+
+


### PR DESCRIPTION
Maintains indices after transform by rerunning `findInstances`. We could make it a little more performant maybe by iterating indices but this is the more consistent approach.

Wasn't exactly sure how to best write a test for this case so I kept the test simple.

Fixes #85 