### PR TITLE
[codex] Fix package main entry

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.3",
   "description": "Display mermaid diagrams in mdx files.",
   "types": "index.d.ts",
-  "main": "lib/mdxast-mermaid.js",
+  "main": "lib/mdxast-mermaid.cjs",
   "exports": {
     ".": {
       "require": "./lib/mdxast-mermaid.cjs",


### PR DESCRIPTION
## Summary

This fixes the legacy package `main` entry for `mdx-mermaid`.

The published package currently declares `main` as `lib/mdxast-mermaid.js`, but the package output contains `lib/mdxast-mermaid.cjs` and `lib/mdxast-mermaid.mjs`; `lib/mdxast-mermaid.js` is not emitted or packaged. Tools that still consult `main` can therefore resolve a missing file even though the modern `exports` map points to valid files.

## Change

- Point `main` at `lib/mdxast-mermaid.cjs`, matching the generated CommonJS entry and the existing `exports["."].require` target.

## Validation

- `npm pack mdx-mermaid@2.0.3 --dry-run --json` confirmed the published tarball contains `lib/mdxast-mermaid.cjs` / `lib/mdxast-mermaid.mjs` and not `lib/mdxast-mermaid.js`.
- `PUPPETEER_SKIP_DOWNLOAD=true corepack yarn install --immutable`
- `corepack yarn workspace mdx-mermaid build`
- `npm pack --dry-run --json` from `lib/`
- `node -e "const fs=require('fs'); const p=require('./lib/package.json'); console.log(JSON.stringify({main:p.main, mainExists:fs.existsSync('./lib/'+p.main), requireExport:p.exports['.'].require, requireExists:fs.existsSync('./lib/'+p.exports['.'].require), importExport:p.exports['.'].import, importExists:fs.existsSync('./lib/'+p.exports['.'].import)}, null, 2))"`
- `git diff --check`

I also tried `corepack yarn workspace mdx-mermaid test`; the suites failed before running tests because Jest/JSDOM initialization throws `TypeError: Cannot read properties of undefined (reading 'testEnvironmentOptions')` in this local Node environment. I also tried `corepack yarn workspace mdx-mermaid dist`; it fails on Windows because the script uses Unix `cp`. Neither failure is caused by the manifest-only change in this PR.