### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "mdx-mermaid-workspace",
   "version": "2.0.4",
+  "bugs": {
+    "url": "https://github.com/sjwall/mdx-mermaid/issues"
+  },
   "packageManager": "yarn@3.4.1",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.